### PR TITLE
make `brew audit --strict` happy

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -4,6 +4,7 @@ class Ffmpeg < Formula
   url "https://ffmpeg.org/releases/ffmpeg-4.2.1.tar.xz"
   version "4.2.1-with-options" # to distinguish from homebrew-core's ffmpeg
   sha256 "cec7c87e9b60d174509e263ac4011b522385fd0775292e1670ecc1180c9bb6d4"
+  revision 1
   head "https://github.com/FFmpeg/FFmpeg.git"
 
   # This formula is for people that will compile with their chosen options
@@ -176,6 +177,7 @@ class Ffmpeg < Formula
     # Build and install additional FFmpeg tools
     system "make", "alltools"
     bin.install Dir["tools/*"].select { |f| File.executable? f }
+    mv bin/"python", pkgshare/"python", :force => true
 
     if build.with? "tesseract"
       opoo <<~EOS


### PR DESCRIPTION
It works as it is, but I think it’s better if we consider here as well the suggestion made for the homebrew-core formula.