### PR TITLE
Switch from NASM to YASM

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -28,7 +28,7 @@ class Ffmpeg < Formula
   option "with-libvmaf", "Enable libvmaf scoring library"
   option "with-libxml2", "Enable libxml2 library"
 
-  depends_on "nasm" => :build
+  depends_on "yasm" => :build
   depends_on "pkg-config" => :build
   depends_on "texi2html" => :build
 
@@ -92,6 +92,7 @@ class Ffmpeg < Formula
       --cc=#{ENV.cc}
       --host-cflags=#{ENV.cflags}
       --host-ldflags=#{ENV.ldflags}
+      --x86asmexe=yasm
       --enable-gpl
       --enable-libaom
       --enable-libdav1d

--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -28,9 +28,9 @@ class Ffmpeg < Formula
   option "with-libvmaf", "Enable libvmaf scoring library"
   option "with-libxml2", "Enable libxml2 library"
 
-  depends_on "yasm" => :build
   depends_on "pkg-config" => :build
   depends_on "texi2html" => :build
+  depends_on "yasm" => :build
 
   depends_on "aom"
   depends_on "dav1d"


### PR DESCRIPTION
This is a quick workaround for #30. I was able to reproduce the issue and switching to YASM like so fixed it. This probably should not be a long-term fix as ffmpeg intentionally prefers NASM (see https://github.com/FFmpeg/FFmpeg/commit/4f9297ac3b39098547863d28fbc8d2a906d5be49), but they basically both do the same thing as I understand it so it's not a big deal to do this for now.

Fixes #30