### PR TITLE
do not build twice for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,3 +52,8 @@ notifications:
   email:
     on_success: never
     on_failure: always
+
+branches:
+  only:
+    - "master"
+


### PR DESCRIPTION
this disables Travis builds for all branches, so they will be only triggered in PRs