### PR TITLE
enable neon

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -5,6 +5,7 @@ class Ffmpeg < Formula
   version "5.0-with-options" # to distinguish from homebrew-core's ffmpeg
   sha256 "51e919f7d205062c0fd4fae6243a84850391115104ccf1efc451733bc0ac7298"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/FFmpeg/FFmpeg.git"
 
   option "with-chromaprint", "Enable the Chromaprint audio fingerprinting library"
@@ -123,6 +124,7 @@ class Ffmpeg < Formula
     if OS.mac?
       args << "--enable-opencl"
       args << "--enable-videotoolbox"
+      args << "--enable-neon" if Hardware::CPU.arm?
     end
 
     args << "--disable-htmlpages" # The same info is accessible through the man pages.


### PR DESCRIPTION
This is to benefit of neon on Apple M1 and should fix https://github.com/homebrew-ffmpeg/homebrew-ffmpeg/issues/86.