### PR TITLE
Make --enable-libvmaf optional

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -109,7 +109,6 @@ class Ffmpeg < Formula
       --enable-libopus
       --enable-libsnappy
       --enable-libtheora
-      --enable-libvmaf
       --enable-libvorbis
       --enable-libvpx
       --enable-libx264


### PR DESCRIPTION
From what I can see, this was mostly made optional in 982466087a2e351fb98659768d3fc6e6908e03d5 except that it's still in the static list of build arguments so it's always on.