### PR TITLE
Support libplacebo

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -20,6 +20,7 @@ class Ffmpeg < Formula
   option "with-libaribcaption", "Enable ARIB STD-B24 based broadcast captions"
   option "with-libmodplug", "Enable module/tracker files as inputs via libmodplug"
   option "with-libopenmpt", "Enable module/tracker files as inputs via libopenmpt"
+  option "with-libplacebo", "Enable GPU-accelerated image/video processing primitives"
   option "with-librist", "Enable Reliable Internet Stream Transport (RIST) support"
   option "with-librsvg", "Enable SVG files as inputs via librsvg"
   option "with-libsoxr", "Enable the soxr resample library"
@@ -78,6 +79,7 @@ class Ffmpeg < Formula
   depends_on "libgsm" => :optional
   depends_on "libmodplug" => :optional
   depends_on "libopenmpt" => :optional
+  depends_on "libplacebo" => :optional
   depends_on "librist" => :optional
   depends_on "librsvg" => :optional
   depends_on "libsoxr" => :optional
@@ -213,6 +215,12 @@ class Ffmpeg < Formula
       ENV.prepend_path "PKG_CONFIG_PATH", Formula["jack"].opt_lib/"pkgconfig"
       args << "--enable-libjack"
       args << "--enable-indev=jack"
+    end
+
+    if build.with? "libplacebo"
+      ENV.prepend_path "PKG_CONFIG_PATH", Formula["libplacebo"].opt_lib/"pkgconfig"
+      args << "--enable-libplacebo"
+      args << "--enable-vulkan"
     end
 
     if build.with? "libzvbi"

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ This formula features the following libraries optionally:
 | `libgsm`         | libgsm support                                                   |
 | `libmodplug`     | Enable module/tracker files as inputs via libmodplug             |
 | `libopenmpt`     | Enable module/tracker files as inputs via libopenmpt             |
-| `libplacebo`     |  Enable GPU-accelerated image/video processing primitives        |
+| `libplacebo`     | Enable GPU-accelerated image/video processing primitives         |
 | `librist`        | RIST support                                                     |
 | `librsvg`        | SVG files as inputs via librsvg                                  |
 | `libsoxr`        | soxr resample library                                            |

--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@ This is a 3<sup>rd</sup> party tap for [Homebrew](https://brew.sh/). It provides
 
 Contents:
 
-- [Installation and usage](#installation-and-usage)
-  - [Installing with options](#installing-with-options)
-  - [Installing latest Git version (`HEAD`)](#installing-latest-git-version-head)
-- [Updating](#updating)
-- [Included libraries](#included-libraries)
-- [Troubleshooting](#troubleshooting)
-- [Issues](#issues)
-- [Maintainers](#maintainers)
+- [homebrew-ffmpeg](#homebrew-ffmpeg)
+  - [Installation and usage](#installation-and-usage)
+    - [Installing with options](#installing-with-options)
+    - [Installing latest Git version (`HEAD`)](#installing-latest-git-version-head)
+  - [Updating](#updating)
+  - [Included libraries](#included-libraries)
+  - [Troubleshooting](#troubleshooting)
+  - [Issues](#issues)
+  - [Maintainers](#maintainers)
 
 ## Installation and usage
 
@@ -117,6 +118,7 @@ This formula features the following libraries optionally:
 | `libgsm`         | libgsm support                                                   |
 | `libmodplug`     | Enable module/tracker files as inputs via libmodplug             |
 | `libopenmpt`     | Enable module/tracker files as inputs via libopenmpt             |
+| `libplacebo`     |  Enable GPU-accelerated image/video processing primitives        |
 | `librist`        | RIST support                                                     |
 | `librsvg`        | SVG files as inputs via librsvg                                  |
 | `libsoxr`        | soxr resample library                                            |


### PR DESCRIPTION
This is almost identical to #129 and adds support for `libplacebo` now the issues with the libplacebo homebrew formula discussed in issue #128 have been resolved