### PR TITLE
enable-libopenvino rather than enable-openvino

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -30,7 +30,7 @@ class Ffmpeg < Formula
   option "with-openh264", "Enable OpenH264 library"
   option "with-openjpeg", "Enable JPEG 2000 image format"
   option "with-openssl", "Enable SSL support"
-  option "with-openvino", "Enable OpenVINO"
+  option "with-openvino", "Enable OpenVINO as a module backend for DNN-based filters"
   option "with-rav1e", "Enable AV1 encoding via librav1e"
   option "with-svt-av1", "Enable Scalable Video Technology for AV1"
   option "with-rtmpdump", "Enable RTMP dumping support"
@@ -206,7 +206,7 @@ class Ffmpeg < Formula
     args << "--enable-libzimg" if build.with? "zimg"
     args << "--enable-libzmq" if build.with? "zeromq"
     args << "--enable-openssl" if build.with? "openssl"
-    args << "--enable-openvino" if build.with? "openvino"
+    args << "--enable-libopenvino" if build.with? "openvino"
 
     # These librares are GPL-incompatible, and require ffmpeg be built with
     # the "--enable-nonfree" flag, which produces unredistributable libraries

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ This formula features the following libraries optionally:
 | `openh264`       | OpenH264 library                                          |
 | `openjpeg`       | JPEG 2000 image format                                    |
 | `openssl`        | SSL support                                               |
-| `openvino`       | OpenVINO (optimizing and deploying deep learning models)  |
+| `openvino`       | OpenVINO for Deep Neural Network based filters            |
 | `rav1e`          | AV1 encoding                                              |
 | `svt-av1`        | Scalable Video Technology for AV1 (encoder and decoder)   |
 | `rtmpdump`       | Dumping RTMP strea s                                      |


### PR DESCRIPTION
1) The current formula passes `--enable-openvino` rather than `--enable-libopenvino`, causing the following error message...

```
$ brew install homebrew-ffmpeg/ffmpeg/ffmpeg --with-openvino
...
Unknown option "--enable-openvino".
```

The correct option, according to https://github.com/FFmpeg/FFmpeg/blob/3565903c638fb77d600d2983701b12300e695a5d/configure#L259 is `--enable-libopenvino`

Tested on macOS 13.7 Ventura, 2024-10-22.

Test case following changes...

```
$ brew install homebrew-ffmpeg/ffmpeg/ffmpeg --with-openvino

$ ffmpeg -h filter=dnn_processing
ffmpeg started on 2024-10-22 at 17:40:51

ffmpeg version 7.1 Copyright (c) 2000-2024 the FFmpeg developers
  built with Apple clang version 14.0.3 (clang-1403.0.22.14.1)
  configuration: --prefix=/opt/homebrew/Cellar/ffmpeg/7.1-with-options --enable-shared --cc=clang --host-cflags= --host-ldflags= --enable-gpl --enable-libaom --enable-libdav1d --enable-libharfbuzz --enable-libmp3lame --enable-libopus --enable-libsnappy --enable-libtheora --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libfontconfig --enable-libfreetype --enable-frei0r --enable-libass --enable-demuxer=dash --enable-opencl --enable-audiotoolbox --enable-videotoolbox --enable-neon --disable-htmlpages --enable-libopenvino
  libavutil      59. 39.100 / 59. 39.100
  libavcodec     61. 19.100 / 61. 19.100
  libavformat    61.  7.100 / 61.  7.100
  libavdevice    61.  3.100 / 61.  3.100
  libavfilter    10.  4.100 / 10.  4.100
  libswscale      8.  3.100 /  8.  3.100
  libswresample   5.  3.100 /  5.  3.100
  libpostproc    58.  3.100 / 58.  3.100
Filter dnn_processing
  Apply DNN processing filter to the input.
    Inputs:
       #0: default (video)
    Outputs:
       #0: default (video)
dnn_processing AVOptions:
   dnn_backend       <int>        ..FV....... DNN backend (from INT_MIN to INT_MAX) (default 1)
     openvino        2            ..FV....... openvino backend flag <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
```

2) Updated the "brew options" description to be more verbose and in line with the formal description in https://github.com/FFmpeg/FFmpeg/blob/3565903c638fb77d600d2983701b12300e695a5d/configure#L259.

⚠️ Caveat emptor: I am not a developer and I do not fully appreciate whether this would have a detrimental effect on something like linux-homebrew.  Nevertheless, it appears to have resolved the above issue under homebrew-ffmpeg on macOS.  It would be prudent to independently validate my hypothesis and fix before accepting this PR.