### PR TITLE
add openapv support, fixes #191

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -27,6 +27,7 @@ class Ffmpeg < Formula
   option "with-tesseract", "Enable the tesseract OCR engine"
   option "with-libvidstab", "Enable vid.stab support for video stabilization"
   option "with-openal-soft", "Enable OpenAL (Open Audio Library) for macOS targets"
+  option "with-openapv", "Enable OpenAPV (Open Advanced Professional Video Codec)"
   option "with-opencore-amr", "Enable Opencore AMR NR/WB audio format"
   option "with-openh264", "Enable OpenH264 library"
   option "with-openjpeg", "Enable JPEG 2000 image format"
@@ -94,6 +95,7 @@ class Ffmpeg < Formula
   depends_on "libvmaf" => :optional
   depends_on "libxml2" => :optional
   depends_on "openal-soft" => :optional
+  depends_on "openapv" => :optional
   depends_on "opencore-amr" => :optional
   depends_on "openh264" => :optional
   depends_on "openjpeg" => :optional
@@ -215,6 +217,7 @@ class Ffmpeg < Formula
     args << "--enable-libzmq" if build.with? "zeromq"
     args << "--enable-openssl" if build.with? "openssl"
     args << "--enable-libopenvino" if build.with? "openvino"
+    args << "--enable-liboapv" if build.with? "openapv"
 
     # These librares are GPL-incompatible, and require ffmpeg be built with
     # the "--enable-nonfree" flag, which produces unredistributable libraries

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ This formula features the following libraries optionally if you pass the respect
 | `--with-tesseract`      | An Optical Character Recognition (OCR) engine             |  |
 | `--with-libvidstab`     | Video stabilization library                               |  |
 | `--with-openal-soft`    | OpenAL (Open Audio Library) for macOS targets             |  |
+| `--with-openapv`        | OpenAPV (Open Advanced Professional Video Codec)          |  |
 | `--with-opencore-amr`   | Opencore AMR NR/WB audio format                           |  |
 | `--with-openh264`       | OpenH264 library                                          |  |
 | `--with-openjpeg`       | JPEG 2000 image format                                    |  |


### PR DESCRIPTION
```
homebrew-ffmpeg on  master using ☁️  default/ took 13.7s
➜ brew reinstall --build-from-source homebrew-ffmpeg/ffmpeg/ffmpeg --with-openapv
Warning: building from source is not supported!
You're on your own. Failures are expected so don't create any issues, please!
==> Fetching downloads for: ffmpeg
==> Fetching homebrew-ffmpeg/ffmpeg/ffmpeg
==> Downloading https://gitlab.archlinux.org/archlinux/packaging/packages/ffmpeg/-/raw/5670ccd86d3b816f49ebc18cab878125eca2f81f/add-av_stream_get_first_dts-for
Already downloaded: /Users/werner/Library/Caches/Homebrew/downloads/89c5a789bbb2e059f601e58af1ca10f4db2a1939f591f896a0240cb1cfb2b8bb--add-av_stream_get_first_dts-for-chromium.patch
==> Downloading https://ffmpeg.org/releases/ffmpeg-8.0.tar.xz
Already downloaded: /Users/werner/Library/Caches/Homebrew/downloads/d4a8e66f9e562f06139fee9396881dd2926d0c7c4abdf3abde11063e69101236--ffmpeg-8.0.tar.xz
==> Reinstalling homebrew-ffmpeg/ffmpeg/ffmpeg --with-openapv
==> Patching
==> Applying add-av_stream_get_first_dts-for-chromium.patch
==> ./configure --enable-shared --cc=clang --host-cflags= --host-ldflags= --enable-gpl --enable-libaom --enable-libdav1d --enable-libharfbuzz --enable-libmp3la
==> make install
==> make alltools
🍺  /opt/homebrew/Cellar/ffmpeg/8.0: 285 files, 51.4MB, built in 1 minute 39 seconds
==> Running `brew cleanup ffmpeg`...
Disable this behaviour by setting `HOMEBREW_NO_INSTALL_CLEANUP=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
Removing: /Users/werner/Library/Caches/Homebrew/ffmpeg--patch--57e26caced5a1382cb639235f9555fc50e45e7bf8333f7c9ae3d49b3241d3f77.patch... (1.2KB)
==> No outdated dependents to upgrade!


homebrew-ffmpeg on  master using ☁️  default/ took 1m 45.9s
➜ which ffmpeg
/opt/homebrew/bin/ffmpeg


homebrew-ffmpeg on  master using ☁️  default/
➜ ffmpeg -encoders | grep apv
ffmpeg version 8.0 Copyright (c) 2000-2025 the FFmpeg developers
  built with Apple clang version 17.0.0 (clang-1700.3.19.1)
  configuration: --prefix=/opt/homebrew/Cellar/ffmpeg/8.0 --enable-shared --cc=clang --host-cflags= --host-ldflags= --enable-gpl --enable-libaom --enable-libdav1d --enable-libharfbuzz --enable-libmp3lame --enable-libopus --enable-libsnappy --enable-libtheora --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libfontconfig --enable-libfreetype --enable-frei0r --enable-libass --enable-demuxer=dash --enable-neon --enable-opencl --enable-audiotoolbox --enable-videotoolbox --disable-htmlpages --enable-liboapv
  libavutil      60.  8.100 / 60.  8.100
  libavcodec     62. 11.100 / 62. 11.100
  libavformat    62.  3.100 / 62.  3.100
  libavdevice    62.  1.100 / 62.  1.100
  libavfilter    11.  4.100 / 11.  4.100
  libswscale      9.  1.100 /  9.  1.100
  libswresample   6.  1.100 /  6.  1.100
 V....D liboapv              liboapv APV (codec apv)
```