### PR TITLE
Ensure pkg-config finds dependencies during ./configure

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -148,7 +148,6 @@ class Ffmpeg < Formula
     ENV.prepend_path "PKG_CONFIG_PATH", HOMEBREW_PREFIX/"lib/pkgconfig"
     ENV.prepend_path "PKG_CONFIG_PATH", HOMEBREW_PREFIX/"share/pkgconfig"
     ENV.prepend_path "PKG_CONFIG_LIBDIR", HOMEBREW_PREFIX/"lib/pkgconfig"
-
     args = %W[
       --prefix=#{prefix}
       --enable-shared


### PR DESCRIPTION
Bugfix: Ensure `pkg-config` finds dependencies during `./configure`
These two env lines solve two related issues:

1. Improper `pkg-config` environment setup means some libraries could be left not found, and by extension
2. pkg-config in ./configure does not respect the outside env's PKG_CONFIG_PATH and PKG_CONFIG_LIBDIR. I think this may be an internal change in homebrew to stop environment leaks to formulae as a security measure.

I solved both of these issues by constructing PKG_CONFIG_PATH and _LIBDIR out of Homebrew's prefix as a reasonable default. I must apologise if it looks like spaghetti, I will fully admit that Ruby is not my first language of choice. Please feel free to suggest anything.