### PR TITLE
Fix #217 Installation fails when using --with-dvd

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
 
     - run: brew test-bot --only-tap-syntax
 
-    - run: brew test-bot --only-formulae --skip-recursive-dependents
+    - run: brew test-bot --only-formulae
       if: github.event_name == 'pull_request'
 
     - name: Upload bottles as artifact

--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -81,8 +81,6 @@ class Ffmpeg < Formula
   depends_on "libbluray" => :optional
   depends_on "libbs2b" => :optional
   depends_on "libcaca" => :optional
-  depends_on "libdvdnav" => :optional
-  depends_on "libdvdread" => :optional
   depends_on "libgsm" => :optional
   depends_on "libmodplug" => :optional
   depends_on "libopenmpt" => :optional
@@ -113,6 +111,14 @@ class Ffmpeg < Formula
   depends_on "xvid" => :optional
   depends_on "zeromq" => :optional
   depends_on "zimg" => :optional
+
+  # `--with-dvd` needs the DVD libraries — plus libdvdcss, a dependency of
+  # libdvdread — installed and discoverable via pkg-config at build time.
+  if build.with? "dvd"
+    depends_on "libdvdcss"
+    depends_on "libdvdnav"
+    depends_on "libdvdread"
+  end
 
   uses_from_macos "bzip2"
   uses_from_macos "zlib"

--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -227,6 +227,9 @@ class Ffmpeg < Formula
     end
 
     if build.with? "dvd"
+      ENV.prepend_path "PKG_CONFIG_PATH", formula_opt_lib("libdvdnav")/"pkgconfig"
+      ENV.prepend_path "PKG_CONFIG_PATH", formula_opt_lib("libdvdread")/"pkgconfig"
+      ENV.prepend_path "PKG_CONFIG_PATH", formula_opt_lib("libdvdcss")/"pkgconfig"
       args << "--enable-libdvdnav"
       args << "--enable-libdvdread"
     end


### PR DESCRIPTION
It seems like Homebrew only includes libraries when they are set with depends_on, and not when they are set as optional. This change makes libdvdnav and libdvdread required when using --with-dvd.

Tested on macOS Tahoe 26.5.1 using my fork:

```sh
brew install Jessecar96/homebrew-ffmpeg/ffmpeg --with-dvd 
...
==> Installing jessecar96/ffmpeg/ffmpeg --with-dvd
==> ./configure --enable-shared --cc=clang --host-cflags= --host-ldflags= --enable-gpl --enable-libaom --enable-libdav1d
==> make install
==> make alltools
🍺  /opt/homebrew/Cellar/ffmpeg/8.1.2: 287 files, 54.2MB, built in 1 minute 24 seconds
```

```sh
% ffmpeg -version 
ffmpeg version 8.1.2 Copyright (c) 2000-2026 the FFmpeg developers
built with Apple clang version 21.0.0 (clang-2100.1.1.101)
configuration: --prefix=/opt/homebrew/Cellar/ffmpeg/8.1.2 --enable-shared --cc=clang --host-cflags= --host-ldflags= --enable-gpl --enable-libaom --enable-libdav1d --enable-libharfbuzz --enable-libmp3lame --enable-libopus --enable-libsnappy --enable-libsvtav1 --enable-libtheora --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libfontconfig --enable-libfreetype --enable-frei0r --enable-libass --enable-demuxer=dash --enable-neon --enable-opencl --enable-audiotoolbox --enable-videotoolbox --disable-htmlpages --enable-libdvdnav --enable-libdvdread
libavutil      60. 26.102 / 60. 26.102
libavcodec     62. 28.102 / 62. 28.102
libavformat    62. 12.102 / 62. 12.102
libavdevice    62.  3.102 / 62.  3.102
libavfilter    11. 14.102 / 11. 14.102
libswscale      9.  5.102 /  9.  5.102
libswresample   6.  3.102 /  6.  3.102

Exiting with exit code 0
```